### PR TITLE
Fix overflow on Memory.copy when len%32==0

### DIFF
--- a/src/unsafe/Memory.sol
+++ b/src/unsafe/Memory.sol
@@ -64,6 +64,8 @@ library Memory {
             src += WORD_SIZE;
         }
 
+        if (len == 0) return;
+
         // Copy remaining bytes
         uint mask = 256 ** (WORD_SIZE - len) - 1;
         assembly {


### PR DESCRIPTION
When the `len` is multiple of 32, the `copy` function fails with overflow